### PR TITLE
Change host address

### DIFF
--- a/hazelcast-mesos-scheduler/src/main/java/com/hazelcast/mesos/util/HazelcastProperties.java
+++ b/hazelcast-mesos-scheduler/src/main/java/com/hazelcast/mesos/util/HazelcastProperties.java
@@ -1,6 +1,7 @@
 package com.hazelcast.mesos.util;
 
 import java.net.Inet4Address;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import static com.hazelcast.mesos.util.Util.option;
@@ -8,7 +9,7 @@ import static java.lang.Integer.parseInt;
 
 public class HazelcastProperties {
     static String HAZELCAST_VERSION = option("HAZELCAST_VERSION").or("3.6");
-    static String HOST = "localhost";
+    static String HOST = option("HOST").or("MESOS_HOSTNAME");
     static String PORT = option("PORT").or("8090");
     static String MESOS_ZK = option("MESOS_ZK").or("zk://localhost:2181/mesos");
     static String MIN_HEAP = option("MIN_HEAP").or("1g");
@@ -46,13 +47,18 @@ public class HazelcastProperties {
     }
 
     public static String getHOST() {
-        try {
-            HOST = Inet4Address.getLocalHost().getHostAddress();
-        } catch (UnknownHostException e) {
-            System.out.println("Could not get host address.");
-        }
+        return HOST == null ? getHostname() : HOST;
+    }
 
-        return HOST;
+    private static String getHostname() {
+        String host;
+        try {
+            host = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            System.out.println("Could not get hostname.");
+            host = "localhost";
+        }
+        return host;
     }
 
     public static String getPORT() {

--- a/hazelcast-mesos-scheduler/src/main/java/com/hazelcast/mesos/util/HazelcastProperties.java
+++ b/hazelcast-mesos-scheduler/src/main/java/com/hazelcast/mesos/util/HazelcastProperties.java
@@ -1,11 +1,14 @@
 package com.hazelcast.mesos.util;
 
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+
 import static com.hazelcast.mesos.util.Util.option;
 import static java.lang.Integer.parseInt;
 
 public class HazelcastProperties {
     static String HAZELCAST_VERSION = option("HAZELCAST_VERSION").or("3.6");
-    static String HOST = option("HOST").or("localhost");
+    static String HOST = "localhost";
     static String PORT = option("PORT").or("8090");
     static String MESOS_ZK = option("MESOS_ZK").or("zk://localhost:2181/mesos");
     static String MIN_HEAP = option("MIN_HEAP").or("1g");
@@ -43,6 +46,12 @@ public class HazelcastProperties {
     }
 
     public static String getHOST() {
+        try {
+            HOST = Inet4Address.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            System.out.println("Could not get host address.");
+        }
+
         return HOST;
     }
 

--- a/marathon.json
+++ b/marathon.json
@@ -8,7 +8,6 @@
   ],
   "env": {
     "HAZELCAST_VERSION": "3.6",
-    "HOST": "localhost",
     "PORT": "8090",
     "MESOS_ZK": "zk://localhost:2181/mesos",
     "MIN_HEAP": "1g",


### PR DESCRIPTION
small fixup,
host address of HTTP server should not be "localhost", it must be address of host where mesos master schedule your framework. Otherwise, Executors will not be able to download URIs because executors will not run on the same host where framework runs.

You also have to delete exporting HOST command from startup.sh (I would but could not find it, donno why :)). You can not export it because of same reason, you do not know where your framework will be scheduled unless you are using marathon constraint which  does not make sense here.
